### PR TITLE
fix: Remove provider block from terraform.tf

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -7,7 +7,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-}


### PR DESCRIPTION
## Description

Provider block in the module is depricated since version azurerm 4.x

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Change Log

* Removed provider block from terraform.tf


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)